### PR TITLE
[lag2] enhance lag2-minlink test

### DIFF
--- a/ansible/roles/test/tasks/lag_minlink.yml
+++ b/ansible/roles/test/tasks/lag_minlink.yml
@@ -12,8 +12,27 @@
         login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
       connection: switch
     
-    - pause:
-        seconds: "{{ wait_down_time }}"
+    - name: Set delay
+      set_fact:
+        delay: 5
+
+    - name: Set retries
+      set_fact:
+        retries: "{{ (wait_down_time / delay | float) | round(0, 'ceil') }}"
+
+    - name: Let portchannel react to neighbor interface shutdown
+      pause:
+        seconds: "{{ deselect_time }}"
+
+    - name: "Verify PortChannel interfaces are up correctly"
+      shell: bash -c "teamdctl {{ po }} state dump" | python -c "import sys, json; print json.load(sys.stdin)['ports']['{{ item }}']['runner']['selected']"
+      register: out
+      until: out.stdout == "True"
+      with_items: "{{ po_interfaces.keys() }}"
+      when: item != "{{ flap_intf }}"
+      become: "yes"
+      retries: "{{ retries | int }}"
+      delay: "{{ delay }}"
     
     - lag_facts: host={{ inventory_hostname }}
     
@@ -44,8 +63,14 @@
         login: "{{switch_login[hwsku_map[peer_hwsku]]}}"
       connection: switch
     
-    - pause:
-        seconds: 35
+    - name: "Verify PortChannel interfaces are up correctly"
+      shell: bash -c "teamdctl {{ po }} state dump" | python -c "import sys, json; print json.load(sys.stdin)['ports']['{{ item }}']['link']['up']"
+      register: out
+      until: out.stdout == "True"
+      with_items: "{{ po_interfaces.keys() }}"
+      become: "yes"
+      retries: "{{ retries | int }}"
+      delay: "{{ delay }}"
     
     - lag_facts: host={{ inventory_hostname }}
     

--- a/ansible/roles/test/tasks/single_lag_test.yml
+++ b/ansible/roles/test/tasks/single_lag_test.yml
@@ -31,7 +31,8 @@
 - name: test fanout interface (physical) flap and lacp keep correct po status follow minimum links requirement
   include: lag_minlink.yml
   vars:
-    wait_down_time: 35
+    deselect_time: 5
+    wait_down_time: 30
 
 ### Now figure out remote VM and interface info for the flapping lag member and run minlink test
 - set_fact:
@@ -45,4 +46,5 @@
 - name: test vm interface flap (no physical port down, more like remote port lock) that lag interface can change to correct po status follow minimum links requirement
   include: lag_minlink.yml
   vars: 
+    deselect_time: 95
     wait_down_time: 120


### PR DESCRIPTION
Change-Id: I165d6ae8bc5ab2100b9d26c1d8c7ad02f0252cd8
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Remove unnecessary pauses, add periodic polling for expected state
Fixes # (issue) Lag minlink failing after recent changes to teamd.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
Remove unnecessary pauses, add periodic polling for expected state. Reduce overall test duration (50m ->30m for t1-lag), add more time for second scenario ( shutdown arista port ) since it began to fail on some setups. 
#### How did you do it?
Introduce  _deselect_time_ variable, representing time in which the lag member is expected to be deselected ( otherwise we would exit on first poll, and fail "verify lag member deselected" check.
The polling is done with as simple one-liner every 5s, allowing to proceed with the "verify" tasks as soon as the condition is met.
#### How did you verify/test it?
Run lag-minlink test on t1-lag & t0.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
